### PR TITLE
workflow: add runner option to inputs

### DIFF
--- a/.github/workflows/build-ros-debian.yml
+++ b/.github/workflows/build-ros-debian.yml
@@ -22,7 +22,7 @@ on:
       source-prefix:
         type: string
         description: 'Prefix of the source directory for the package'
-        default: '.'
+        default: ''
       runner:
         description: "Runner; For example: ubuntu-latest"
         required: false
@@ -63,7 +63,7 @@ jobs:
 
       - name: Build debian package
         run: |
-          docker run --rm -v ./${{ inputs.source-prefix }}:/work --platform ${{ inputs.platform }} buildenv:current
+          docker run --rm -v $(pwd)/${{ inputs.source-prefix }}:/work --platform ${{ inputs.platform }} buildenv:current
 
       - name: Upload artifacts to github actions/checkout
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build-ros-debian.yml
+++ b/.github/workflows/build-ros-debian.yml
@@ -23,10 +23,15 @@ on:
         type: string
         description: 'Prefix of the source directory for the package'
         default: '.'
+      runner:
+        description: "Runner; For example: ubuntu-latest"
+        required: false
+        type: string
+        default: 'ubuntu-latest'
 
 jobs:
   build-and-publish:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This enables use of third-party runners like buildjet