### PR TITLE
Allow version pinning

### DIFF
--- a/Dockerfile.debian-buildenv
+++ b/Dockerfile.debian-buildenv
@@ -42,7 +42,7 @@ RUN echo "#!/bin/bash" > /build_package.sh && \
     echo "cp ../*.ddeb /work/output" >> /build_package.sh && \
     chmod +x /build_package.sh
 
-COPY fix_debian_control.sh.sh /scripts/fix_debian_control.sh.sh
+COPY fix_debian_control.sh /scripts/fix_debian_control.sh
 WORKDIR /work
 
 CMD [ "/ros_entrypoint.sh", "/build_package.sh" ]

--- a/Dockerfile.debian-buildenv
+++ b/Dockerfile.debian-buildenv
@@ -35,7 +35,7 @@ RUN echo "#!/bin/bash" > /build_package.sh && \
     echo "rosdep update --rosdistro=$ROS2_DISTRO" >> /build_package.sh && \
     echo "rosdep install --from-paths . -y -v" >> /build_package.sh && \
     echo "bloom-generate rosdebian" >> /build_package.sh && \
-    echo "/scripts/fix_debian_control.sh.sh" >> /build_package.sh && \
+    echo "/scripts/fix_debian_control.sh" >> /build_package.sh && \
     echo "fakeroot debian/rules binary" >> /build_package.sh && \
     echo "mkdir -p /work/output" >> /build_package.sh && \
     echo "cp ../*.deb /work/output" >> /build_package.sh && \

--- a/Dockerfile.debian-buildenv
+++ b/Dockerfile.debian-buildenv
@@ -35,12 +35,14 @@ RUN echo "#!/bin/bash" > /build_package.sh && \
     echo "rosdep update --rosdistro=$ROS2_DISTRO" >> /build_package.sh && \
     echo "rosdep install --from-paths . -y -v" >> /build_package.sh && \
     echo "bloom-generate rosdebian" >> /build_package.sh && \
+    echo "/scripts/fix_debian_control.sh.sh" >> /build_package.sh && \
     echo "fakeroot debian/rules binary" >> /build_package.sh && \
     echo "mkdir -p /work/output" >> /build_package.sh && \
     echo "cp ../*.deb /work/output" >> /build_package.sh && \
     echo "cp ../*.ddeb /work/output" >> /build_package.sh && \
     chmod +x /build_package.sh
 
+COPY fix_debian_control.sh.sh /scripts/fix_debian_control.sh.sh
 WORKDIR /work
 
 CMD [ "/ros_entrypoint.sh", "/build_package.sh" ]

--- a/fix_debian_control.sh
+++ b/fix_debian_control.sh
@@ -1,9 +1,16 @@
 #!/bin/bash
 
+# rosdep and bloom do not support dependency version pinning.
+# Although rosdep allows versioned package names (e.g., `package=1.2.3`)
+# during dependency installation, bloom does not correctly process these
+# versioned names when generating Debian metadata files.
+
+# Namely the Debian control file should use the format `package (= 1.2.3)`
+# for versioned dependencies. This script updates lines in the 'Build-Depends'
+# and 'Depends' fields to match this format.
+
 CONTROL_FILE="debian/control"
 
-# Fix dependency versioning in Build-Depends and Depends fields produced by bloom-generate
-# e.g. `package=1.2.3` becomes `package (= 1.2.3)`
 sed -i -E '
   /^(Build-Depends:|Depends:)/ {
     :a

--- a/fix_debian_control.sh
+++ b/fix_debian_control.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+CONTROL_FILE="debian/control"
+
+# Fix dependency versioning in Build-Depends and Depends fields produced by bloom-generate
+# e.g. `package=1.2.3` becomes `package (= 1.2.3)`
+sed -i -E '
+  /^(Build-Depends:|Depends:)/ {
+    :a
+    N
+    /^(Build-Depends:|Depends:).*\n/!ba
+    s/([a-zA-Z0-9.-]+)=([a-zA-Z0-9.-]+)/\1 (= \2)/g
+  }
+' "$CONTROL_FILE"

--- a/fix_debian_control.sh
+++ b/fix_debian_control.sh
@@ -9,6 +9,6 @@ sed -i -E '
     :a
     N
     /^(Build-Depends:|Depends:).*\n/!ba
-    s/([a-zA-Z0-9.-]+)=([a-zA-Z0-9.-]+)/\1 (= \2)/g
+    s/([a-z0-9.-]+)=([a-z0-9.-]+)/\1 (= \2)/g
   }
 ' "$CONTROL_FILE"

--- a/fix_debian_control.sh
+++ b/fix_debian_control.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 # rosdep and bloom do not support dependency version pinning.
-# Although rosdep allows versioned package names (e.g., `package=1.2.3`)
+# Rationale: https://answers.ros.org/question/376259/rosdep-install-specific-version-of-dependencies/
+
+# Although rosdep allows versions within package names (e.g., `package=1.2.3`)
 # during dependency installation, bloom does not correctly process these
 # versioned names when generating Debian metadata files.
 


### PR DESCRIPTION
### Context

To debianize ROS2 packages we use _rosdep_ to install packages dependencies and _bloom_ to generate the Debian packaging metadata. And this way follows the [official ROS2 way](https://docs.ros.org/en/rolling/How-To-Guides/Building-a-Custom-Debian-Package.html) of doing so.

Unfortunately, _rosdep_ does not provide dependency version pinning as far as I can tell ([rosdep yaml format](https://docs.ros.org/en/independent/api/rosdep/html/rosdep_yaml_format.html)), consequently nor does _bloom_ support it.

However, _rosdep_ does not block users from calling their dependencies whatever they wish. So one can make the package name include a version name that could be handle by the package manager. For example:

```
package_name_ros2:
  ubuntu: [package_name_debian=1.2.3]
```

_rosdep_ using `apt` will successfully install the package above with the desired version. But _bloom_ will not handle it properly since this doesn't adhere to the debian format. 

### Changes

This PR introduces a workaround to allow dependency pinning. 

When a version is provided as above in the _rosdep_ sources, the command `bloom-generate rosdebian` will still generate a `debian/control` file but with a dependency on package `package_name_debian=1.2.3`. The workaround is to find and replace these occurrences with correct debian syntax, e.g. `package_name_debian (= 1.2.3)`.

### Consequences

_rosdep_ does not support specific version dependencies [by design](https://answers.ros.org/question/376259/rosdep-install-specific-version-of-dependencies/):

> we specifically don't allow specifying versions as we have no way to generically do conflict resolution between packages which might declare different versions selected.

The responsibility falls on us to ensure that we do not offer packages that are intended to co-exist on a system, that would depend on different versions of the same dependency. 

### Testing

[CI run](https://github.com/Auterion/auterion-sdk/actions/runs/10177805524/job/28150073116) that included a dependency on `ros-humble-px4-msgs=0.0.200-0jammy`  

### Alternate approach

Have all our ROS2 debian packages include their version within their name, e.g. `ros-humble-px4-msgs3.0.8`. I've just noticed this seems to be the approach taken by the [base rosdep sources](https://raw.githubusercontent.com/ros/rosdistro/master/rosdep/base.yaml).

Pros:
- This follows the official ROS2 way to debianize packages
- This will probably also fix the issue we've had, where `apt` fails to install a package that has a dependency on different package version that is not the latest

Cons:
- Each new (breaking) version of a ROS2 package essentially becomes a new independent Debian package
- When a dependency is updated, we need to manually change the name of that dependency in the package we're building