### PR TITLE
ci: update deprecated artifact@v3 references

### DIFF
--- a/.github/workflows/build-ros-debian.yml
+++ b/.github/workflows/build-ros-debian.yml
@@ -66,7 +66,7 @@ jobs:
           docker run --rm -v $(pwd)/${{ inputs.source-prefix }}:/work --platform ${{ inputs.platform }} buildenv:current
 
       - name: Upload artifacts to github actions/checkout
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: debian-packages
           path: ${{ inputs.source-prefix }}/output/*.deb


### PR DESCRIPTION
Replaces the deprecated artifact v3 actions with v4, to prevent brownouts and future problems. See Github blog post announcing this here: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/.