### PR TITLE
Make debian file names unique

### DIFF
--- a/.github/workflows/build-ros-debian.yml
+++ b/.github/workflows/build-ros-debian.yml
@@ -65,10 +65,17 @@ jobs:
         run: |
           docker run --rm -v $(pwd)/${{ inputs.source-prefix }}:/work --platform ${{ inputs.platform }} buildenv:current
 
+      - name: Generate artifact name
+        run: |
+          # remove forward slashes from platform name
+          platform_name="${{ inputs.platform }}"
+          platform_name="${platform_name//\//-}"
+          echo "ARTIFACT_NAME=debian-packages_${platform_name}_${{ inputs.ubuntu-distro }}_${{ inputs.ros2-distro }}_${{ inputs.runner }}" >> $GITHUB_ENV
+
       - name: Upload artifacts to github actions/checkout
         uses: actions/upload-artifact@v4
         with:
-          name: debian-packages
+          name: ${{ env.ARTIFACT_NAME }}
           path: ${{ inputs.source-prefix }}/output/*.deb
       
       - name: Generate upload information


### PR DESCRIPTION
I prematurely merged #6, since v3 of the `upload-artifact` action seemed to have been fully deprecated and was preventing workflows from running. I didn't do my due diligence to check that v4 would not break workflows - which it of course did. Debian file names now need to be unique, but in all our uses of this workflow we used the same name multiple times.

This PR now uses the four workflow inputs to define a unique debian file name:

```
debian-packages_{PLATFORM}_{UBUNTU_DISTRO}_{ROS2_DISTRO}_{RUNNER}
```

**Testing**

Auterion SDK: https://github.com/Auterion/auterion-sdk/actions/runs/12695726633