### PR TITLE
fix: catch dependency conflict errors

### DIFF
--- a/Dockerfile.debian-buildenv
+++ b/Dockerfile.debian-buildenv
@@ -30,7 +30,9 @@ RUN curl -1sLf \
 RUN echo "yaml file:///work/rosdep-${ROS2_DISTRO}.yaml" > /etc/ros/rosdep/sources.list.d/99-local.list
 
 RUN echo "#!/bin/bash" > /build_package.sh && \
-    echo "/scripts/update_rosdep_yaml.sh /work/rosdep-${ROS2_DISTRO}.yaml" >> /build_package.sh && \
+    echo "set -e" >> /build_package.sh && \
+    echo "/scripts/update_rosdep_yaml.sh /work/rosdep-$ROS2_DISTRO.yaml" >> /build_package.sh && \
+    echo "/scripts/install_rosdeps.py /work/rosdep-$ROS2_DISTRO.yaml" >> /build_package.sh && \
     echo "rosdep update --rosdistro=$ROS2_DISTRO" >> /build_package.sh && \
     echo "rosdep install --from-paths . -y -v" >> /build_package.sh && \
     echo "bloom-generate rosdebian" >> /build_package.sh && \

--- a/scripts/install_rosdeps.py
+++ b/scripts/install_rosdeps.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+
+# Usage: python3 install_rosdeps.py path/to/rosdep.yaml
+
+# This script installs system dependencies listed in a rosdep YAML file using APT.
+# It should be run before `rosdep install` to ensure specific package versions are installed.
+
+# Why it's needed:
+# `rosdep` only checks if a required package is present, not whether the correct version is installed.
+# APT, however, will detect version mismatches and prevent incompatible packages from being installed.
+
+# This script helps catch issues like version conflicts between dependencies. For example:
+#   pkg_A depends on pkg_C (v1)
+#   pkg_B depends on pkg_C (v2)
+#   pkg_A depends on pkg_B
+# In this case, it's impossible to satisfy all dependencies correctly. This script will surface such conflicts.
+
+# Note:
+# APT can't automatically resolve these version mismatches.
+# It's the package maintainer's responsibility to ensure that all pinned dependency versions are compatible.
+
+
+import sys
+import yaml
+import subprocess
+
+def run_command(command):
+    process = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+
+    for stdout_line in iter(process.stdout.readline, ""):
+        print(stdout_line, end="")
+    for stderr_line in iter(process.stderr.readline, ""):
+        print(stderr_line, end="")
+
+    process.stdout.close()
+    process.stderr.close()
+    return_code = process.wait()
+
+    if return_code != 0:
+        print(f"Error executing command: {command}")
+        sys.exit(return_code)
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python3 install_rosdeps.py path/to/rosdep.yaml")
+        sys.exit(1)
+
+    file_path = sys.argv[1]
+
+    print(f"Reading dependencies from {file_path}")
+
+    with open(file_path, 'r') as f:
+        data = yaml.safe_load(f)
+
+    packages = set()
+
+    for key, val in data.items():
+        if isinstance(val, dict) and 'ubuntu' in val:
+            ubuntu_deps = val['ubuntu']
+            if isinstance(ubuntu_deps, str):
+                packages.add(ubuntu_deps)
+            elif isinstance(ubuntu_deps, list):
+                packages.update(ubuntu_deps)
+
+    print(f"Manually installing the following packages via APT, before rosdep scan:")
+    for package in packages:
+        print(f"  - {package}")
+
+    run_command("apt update")
+    run_command(f"apt install -y {' '.join(sorted(packages))}")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/install_rosdeps.py
+++ b/scripts/install_rosdeps.py
@@ -25,20 +25,11 @@ import yaml
 import subprocess
 
 def run_command(command):
-    process = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    result = subprocess.run(command, shell=True, text=True)
 
-    for stdout_line in iter(process.stdout.readline, ""):
-        print(stdout_line, end="")
-    for stderr_line in iter(process.stderr.readline, ""):
-        print(stderr_line, end="")
-
-    process.stdout.close()
-    process.stderr.close()
-    return_code = process.wait()
-
-    if return_code != 0:
+    if result.returncode != 0:
         print(f"Error executing command: {command}")
-        sys.exit(return_code)
+        sys.exit(result.returncode)
 
 def main():
     if len(sys.argv) < 2:


### PR DESCRIPTION
### Changes

Currently, the rosdebian workflow will not fail in case of package version conflicts, for example:
- pkg_A depends on pkg_C (v1)
- pkg_B depends on pkg_C (v2)
- pkg_A depends on pkg_B

The workflow will complete successfully, and whichever pkg_C version was installed first will be used because `rosdep` does not have a notion of version and will be satisfied with the first installation candidate. Installing and using pkg_A can then lead to undefined behavior.

This PR adds an `apt install` command before `rosdep install` to install Auterion ROS dependencies, which will return an error in cases of mismatching dependencies. The workflow duration should not be affected, the concerned dependencies will still only be installed once, but with `apt` directly instead of `rosdep`.

### Testing

The following test PR in auterion-sdk checks that the workflow is still successful, but fails in case of conflicting dependencies: https://github.com/Auterion/auterion-sdk/pull/123

This failure case has auterion-sdk depend on `px4-msgs=3.2.2*` and px4-ros2-cpp depend on `px4-msgs=3.2.1*`

```
Manually installing the following packages via APT, before rosdep scan:
  - ros-foxy-px4-msgs=3.2.2-0focal
  - ros-foxy-px4-ros2-cpp=1.5.0-0focal
  - ros-foxy-auterion-core-msgs=0.0.5-0focal
  
...

The following packages have unmet dependencies:
 ros-foxy-px4-ros2-cpp : Depends: ros-foxy-px4-msgs (= 3.2.1-0focal) but 3.2.2-0focal is to be installed

E: Unable to correct problems, you have held broken packages.
 ```
