### PR TITLE
Switch to self-hosted runners

### DIFF
--- a/.github/workflows/build-ros-debian.yml
+++ b/.github/workflows/build-ros-debian.yml
@@ -24,14 +24,14 @@ on:
         description: 'Prefix of the source directory for the package'
         default: '.'
       runner:
-        description: "Runner; For example: ubuntu-latest"
+        description: "Workflow runner (e.g. 8cpu-linux-x64)"
         required: false
         type: string
-        default: 'ubuntu-latest'
+        default: ${{ vars.RUNSON_CI_BUILDER_DEFAULT_X64 }}
 
 jobs:
   build-and-publish:
-    runs-on: ${{ inputs.runner }}
+    runs-on: [runs-on,"runner=${{ inputs.runner }}","run-id=${{ github.run_id }}"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -71,7 +71,7 @@ jobs:
           # remove forward slashes from platform name
           platform_name="${{ inputs.platform }}"
           platform_name="${platform_name//\//-}"
-          echo "ARTIFACT_NAME=debian-packages_${platform_name}_${{ inputs.ubuntu-distro }}_${{ inputs.ros2-distro }}_${{ inputs.runner }}" >> $GITHUB_ENV
+          echo "ARTIFACT_NAME=debian-packages_${platform_name}_${{ inputs.ubuntu-distro }}_${{ inputs.ros2-distro }}" >> $GITHUB_ENV
 
       - name: Upload artifacts to github actions/checkout
         uses: actions/upload-artifact@v4

--- a/Dockerfile.debian-buildenv
+++ b/Dockerfile.debian-buildenv
@@ -36,12 +36,15 @@ RUN curl -1sLf \
   'https://dl.cloudsmith.io/public/auterion/public/setup.deb.sh' \
   | bash
 
-RUN echo "yaml file:///work/rosdep-${ROS2_DISTRO}.yaml" > /etc/ros/rosdep/sources.list.d/99-local.list
-
 RUN echo "#!/bin/bash" > /build_package.sh && \
     echo "set -e" >> /build_package.sh && \
-    echo "/scripts/update_rosdep_yaml.sh /work/rosdep-$ROS2_DISTRO.yaml" >> /build_package.sh && \
-    echo "/scripts/install_rosdeps.py /work/rosdep-$ROS2_DISTRO.yaml" >> /build_package.sh && \
+    echo "if [[ -f \"/work/rosdep-$ROS2_DISTRO.yaml\" ]]; then" >> /build_package.sh && \
+    echo "  /scripts/update_rosdep_yaml.sh /work/rosdep-$ROS2_DISTRO.yaml" >> /build_package.sh && \
+    echo "  /scripts/install_rosdeps.py /work/rosdep-$ROS2_DISTRO.yaml" >> /build_package.sh && \
+    echo "  echo \"yaml file:///work/rosdep-$ROS2_DISTRO.yaml\" > /etc/ros/rosdep/sources.list.d/99-local.list" >> /build_package.sh && \
+    echo "else" >> /build_package.sh && \
+    echo "  echo \"rosdep YAML file not found.\"" >> /build_package.sh && \
+    echo "fi" >> /build_package.sh && \
     echo "rosdep update --rosdistro=$ROS2_DISTRO" >> /build_package.sh && \
     echo "rosdep install --from-paths . -y -v" >> /build_package.sh && \
     echo "bloom-generate rosdebian" >> /build_package.sh && \


### PR DESCRIPTION
The `runner` input can/should now be one of the shared `RUNSON_` workflow variables. 

- `RUNSON_CI_BUILDER_DEFAULT_ARM64` = `8cpu-linux-arm64`
- `RUNSON_CI_BUILDER_DEFAULT_X64` = `8cpu-linux-x64`
- `RUNSON_CI_RUNNER_DEFAULT` = `2cpu-linux-x64`