### PR TITLE
Switch from apt to apt-get in docker to remove warnings

### DIFF
--- a/Dockerfile.debian-buildenv
+++ b/Dockerfile.debian-buildenv
@@ -15,7 +15,7 @@ ARG ROS2_DISTRO
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 4B63CF8FDE49746E98FA01DDAD19BAB3CBF125EA
-RUN apt update && apt install -y \
+RUN apt-get update && apt-get install -y \
     dh-make \
     python3-bloom \
     python3-rosdep \


### PR DESCRIPTION
This removes warnings when building the docker image. Using `apt` gives a warning about how it should be used with caution in scripts. 

Here is the warning that this removes:
```
WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
```

This was tested by building the docker image with the change. 