### PR TITLE
fix: handle missing rosdep.yaml case

### DIFF
--- a/Dockerfile.debian-buildenv
+++ b/Dockerfile.debian-buildenv
@@ -27,12 +27,14 @@ RUN curl -1sLf \
   'https://dl.cloudsmith.io/public/auterion/public/setup.deb.sh' \
   | bash
 
-RUN echo "yaml file:///work/rosdep-${ROS2_DISTRO}.yaml" > /etc/ros/rosdep/sources.list.d/99-local.list
-
 RUN echo "#!/bin/bash" > /build_package.sh && \
     echo "set -e" >> /build_package.sh && \
-    echo "/scripts/update_rosdep_yaml.sh /work/rosdep-$ROS2_DISTRO.yaml" >> /build_package.sh && \
-    echo "/scripts/install_rosdeps.py /work/rosdep-$ROS2_DISTRO.yaml" >> /build_package.sh && \
+    echo "ROSDEP_YAML=/work/rosdep-$ROS2_DISTRO.yaml" >> /build_package.sh && \
+    echo "if [ -f \$ROSDEP_YAML ]; then" >> /build_package.sh && \
+    echo "  /scripts/update_rosdep_yaml.sh \$ROSDEP_YAML" >> /build_package.sh && \
+    echo "  /scripts/install_rosdeps.py \$ROSDEP_YAML" >> /build_package.sh && \
+    echo "  echo \"yaml file://\$ROSDEP_YAML\" > /etc/ros/rosdep/sources.list.d/99-local.list" >> /build_package.sh && \
+    echo "fi" >> /build_package.sh && \
     echo "rosdep update --rosdistro=$ROS2_DISTRO" >> /build_package.sh && \
     echo "rosdep install --from-paths . -y -v" >> /build_package.sh && \
     echo "bloom-generate rosdebian" >> /build_package.sh && \


### PR DESCRIPTION
### Fix

Check that `rosdep-<ros-distro>.yaml` file exists before trying to edit / use it.
This was causing `px4_msgs` CI to fail, as it does not specify such a file.

### Testing

Tested with px4_msgs test release: https://github.com/Auterion/px4_msgs/actions/runs/14899939717/job/41849593452