### PR TITLE
Followup ros2 expired keyring

### DIFF
--- a/Dockerfile.debian-buildenv
+++ b/Dockerfile.debian-buildenv
@@ -16,8 +16,12 @@ ARG ROS2_DISTRO
 # Temporary fix: fetch new rosdep sources list
 # Required until OSRF updates their docker images with the new keyring
 # Waiting on https://github.com/docker-library/official-images/pull/19162
-RUN rm /etc/apt/sources.list.d/ros2-latest.list && \
-    apt update && apt install curl && \
+RUN if [ "$ROS2_DISTRO" = "humble" ] || [ "$ROS2_DISTRO" = "rolling" ]; then \
+        rm /etc/apt/sources.list.d/ros2-latest.list; \
+    elif [ "$ROS2_DISTRO" = "foxy" ]; then \
+        rm /etc/apt/sources.list.d/ros2-snapshots.list; \
+    fi; \
+    apt update && apt install -y curl && \
     curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg && \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
 


### PR DESCRIPTION
Follow-up to https://github.com/Auterion/ros-debian-workflow/pull/14
The ros2 key rotation [did not work on ubuntu 20.04](https://github.com/Auterion/auterion-sdk/actions/runs/15415141252) because it stores the key in a different location. This fixes that.

### Testing

Tested a full CI run this time to avoid more surprises: https://github.com/Auterion/auterion-sdk/pull/136
- ✅  Focal/Foxy
- ✅  Humble/Jammy
- ✅  Rolling/Noble: `apt update` is running OK. CI is failing because of the [known issue with missing fastrtps_cmake_module](https://auterion.slack.com/archives/C06J4KL9C0P/p1746693034532319?thread_ts=1746682820.506629&cid=C06J4KL9C0P). 
