### PR TITLE
remove ros key fix

### DIFF
--- a/Dockerfile.debian-buildenv
+++ b/Dockerfile.debian-buildenv
@@ -13,19 +13,14 @@ FROM ros:${ROS2_DISTRO}-ros-base-${UBUNTU_DISTRO}
 # Re-request ARGs to make them available in this stage
 ARG ROS2_DISTRO
 
-# Temporary fix: fetch new rosdep sources list
-# Required until OSRF updates their docker images with the new keyring
-# Waiting on https://github.com/docker-library/official-images/pull/19162
-RUN if [ "$ROS2_DISTRO" = "humble" ] || [ "$ROS2_DISTRO" = "jazzy" ] || [ "$ROS2_DISTRO" = "rolling" ]; then \
-        rm /etc/apt/sources.list.d/ros2-latest.list; \
-    elif [ "$ROS2_DISTRO" = "foxy" ]; then \
-        rm /etc/apt/sources.list.d/ros2-snapshots.list; \
-    else \
-        echo "Warning: Unrecognized ROS2_DISTRO '$ROS2_DISTRO'. The apt key might be broken."; \
-    fi; \
-    apt update && apt install -y curl && \
-    curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg && \
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
+# Since Foxy is EOL, we need to replace the apt keys in the image
+RUN if [ "$ROS2_DISTRO" = "foxy" ]; then \
+      echo "Warning: Replacing ros2 apt keys for foxy." && \
+      rm -f /etc/apt/sources.list.d/ros2* && \
+      apt-get update && apt-get install -y curl gnupg && \
+      curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key | gpg --dearmor -o /usr/share/keyrings/ros-archive-keyring.gpg && \
+      echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" > /etc/apt/sources.list.d/ros2.list; \
+    fi
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 4B63CF8FDE49746E98FA01DDAD19BAB3CBF125EA


### PR DESCRIPTION
The ros docker images were [updated](https://hub.docker.com/layers/library/ros/humble-ros-base-jammy/images/sha256-b5873864423bb6f669f32e4df4996e8647aeec3418ddec1ca4b440202ba2bb58) with new apt keys, removing the need for this workaround

EDIT: Actually we need to keep this workaround just for foxy, because it's EOL and no new docker image with new keys is pushed. Only images of later ros2 distro were updated. See: https://github.com/docker-library/official-images/pull/19162/files

### Testing

Testing with auterion-sdk test CI run: https://github.com/Auterion/auterion-sdk/pull/137
(rolling CI failures relating to fastrtps_cmake_module are known and can be ignored)