### PR TITLE
Add manual build scripts

### DIFF
--- a/Dockerfile.debian-buildenv
+++ b/Dockerfile.debian-buildenv
@@ -51,6 +51,7 @@ RUN echo "#!/bin/bash" > /build_package.sh && \
     echo "/scripts/fix_debian_control.sh" >> /build_package.sh && \
     echo "/scripts/fix_debian_parallel_build.sh" >> /build_package.sh && \
     echo "export DEB_BUILD_OPTIONS=\"parallel=\$(nproc) notest nocheck\"" >> /build_package.sh && \
+    echo "fakeroot debian/rules clean" >> /build_package.sh && \
     echo "fakeroot debian/rules binary" >> /build_package.sh && \
     echo "mkdir -p /work/output" >> /build_package.sh && \
     echo "cp ../*.deb /work/output" >> /build_package.sh && \

--- a/Dockerfile.debian-buildenv
+++ b/Dockerfile.debian-buildenv
@@ -49,6 +49,8 @@ RUN echo "#!/bin/bash" > /build_package.sh && \
     echo "rosdep install --from-paths . -y -v" >> /build_package.sh && \
     echo "bloom-generate rosdebian" >> /build_package.sh && \
     echo "/scripts/fix_debian_control.sh" >> /build_package.sh && \
+    echo "/scripts/fix_debian_parallel_build.sh" >> /build_package.sh && \
+    echo "export DEB_BUILD_OPTIONS=\"parallel=\$(nproc) notest nocheck\"" >> /build_package.sh && \
     echo "fakeroot debian/rules binary" >> /build_package.sh && \
     echo "mkdir -p /work/output" >> /build_package.sh && \
     echo "cp ../*.deb /work/output" >> /build_package.sh && \

--- a/README.md
+++ b/README.md
@@ -1,2 +1,50 @@
 # Reusable workflow for building Auterion public ROS2 Debian packages
 
+## Example usage
+```yaml
+jobs:
+  build:
+    name: Build debian packages
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - platform: linux/arm64
+            runner: "buildjet-4vcpu-ubuntu-2204-arm"
+          - platform: linux/amd64
+            runner: "buildjet-2vcpu-ubuntu-2204"
+        distro:
+          - ubuntu: jammy
+            ros2: humble
+          - ubuntu: noble
+            ros2: jazzy
+          - ubuntu: noble
+            ros2: rolling
+
+    uses: Auterion/ros-debian-workflow/.github/workflows/build-ros-debian.yml@main
+    with:
+      platform: ${{ matrix.platform.platform }}
+      ubuntu-distro: ${{ matrix.distro.ubuntu }}
+      ros2-distro: ${{ matrix.distro.ros2 }}
+      runner: ${{ matrix.platform.runner }}
+      source-prefix: px4_ros2_cpp # Optional, defaults to '.'
+    secrets: inherit
+```
+This will also publish the packages to Cloudsmith if the `release` event is triggered.
+
+## Local usage
+Debian packages can be built locally.
+To do so, first build the build environment docker container (only required once):
+```bash
+./build_env.sh
+```
+
+Then, build a package:
+```bash
+./build_pkg.sh <path/to/package> <version> [<.deb dependencies>]
+```
+For example:
+```bash
+./build_pkg.sh px4-ros2-interface-lib/px4_ros2_cpp 0.0.100 \
+    ros-humble-px4-msgs_0.0.100-0jammy_arm64.deb
+```

--- a/build_env.sh
+++ b/build_env.sh
@@ -1,0 +1,16 @@
+platform="linux/arm64"
+ros2_distro="humble"
+ubuntu_distro="jammy"
+# ros2_distro="foxy"
+# ubuntu_distro="focal"
+# ros2_distro="iron"
+# ubuntu_distro="noble"
+# ros2_distro="rolling"
+# ubuntu_distro="noble"
+
+
+docker build . -f Dockerfile.debian-buildenv \
+    --platform $platform \
+    --build-arg="ROS2_DISTRO=$ros2_distro" \
+    --build-arg="UBUNTU_DISTRO=$ubuntu_distro" \
+    -t buildenv:current

--- a/build_pkg.sh
+++ b/build_pkg.sh
@@ -1,0 +1,43 @@
+#! /bin/bash
+
+set -e
+
+if [ $# -lt 2 ]; then
+    echo "Usage: $0 <package_dir> <version> [.deb files]"
+    echo ""
+    echo "Example: $0 px4-ros2-interface-lib/px4_ros2_cpp 0.0.100 path/to/ros-humble-px4-msgs_0.0.100-0jammy_arm64.deb"
+    exit 1
+fi
+
+WORK_DIR=$(realpath "$1")
+shift
+VERSION="$1"
+shift
+
+# Replace version in package.xml
+PACKAGE_XML="$WORK_DIR"/package.xml
+[ ! -f "$PACKAGE_XML" ] && echo "File $PACKAGE_XML is missing" && exit 1
+sed -i "s|<version>.*</version>|<version>$VERSION</version>|" "$PACKAGE_XML"
+
+# Copy deb files to a temporary directory & update the package dependencies
+DEB_TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$DEB_TMP_DIR"' EXIT
+for deb in "$@"; do
+    cp "$deb" "$DEB_TMP_DIR"
+
+    # Extract '<pkg-name>' from 'ros-<ros-version>-<pkg-name>_0.0.1-0jammy_arm64.deb'
+    ros_pkg_version="$(basename "$deb" | sed -n 's/ros-\([^-]*\)-\(.*\)_.*.deb/\2/p')"
+    ros_pkg=$(echo "$ros_pkg_version" | sed -n 's/\(.*\)_\([^_]*\)/\1/p')
+    [ -z "$ros_pkg" ] && echo "Failed to extract ros package name from $deb" && exit 1
+
+    # Replace <pkg-name>=<version> with just <pkg-name> in all rosdep files, since we inject this package.
+    # The drawback is that the final .deb will not depend on the specific version of <pkg-name>.
+    for rosdep in "$WORK_DIR"/rosdep-*.yaml; do
+      sed -i "s|$ros_pkg=.*|$ros_pkg|" "$rosdep"
+    done
+done
+
+docker run --rm -v "$WORK_DIR":/work -v "$DEB_TMP_DIR":/deb --platform linux/arm64 buildenv:current bash -c \
+  'set -e; if [ -n "$(ls /deb/*.deb 2>/dev/null)" ]; then dpkg -i /deb/*.deb; fi; /build_package.sh'
+
+echo "Done, built package is in $WORK_DIR/output"

--- a/scripts/fix_debian_parallel_build.sh
+++ b/scripts/fix_debian_parallel_build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Enable parallel builds for ROS packages
+# This is not needed with debhelper 10+, but ROS (jazzy) still uses 9
+
+RULES_FILE="debian/rules"
+
+sed -i 's/dh_auto_build$/dh_auto_build --parallel/g' "$RULES_FILE"

--- a/scripts/install_rosdeps.py
+++ b/scripts/install_rosdeps.py
@@ -49,16 +49,20 @@ def main():
         if isinstance(val, dict) and 'ubuntu' in val:
             ubuntu_deps = val['ubuntu']
             if isinstance(ubuntu_deps, str):
-                packages.add(ubuntu_deps)
+                if '=' in ubuntu_deps:
+                    packages.add(ubuntu_deps)
             elif isinstance(ubuntu_deps, list):
-                packages.update(ubuntu_deps)
+                for ubuntu_dep in ubuntu_deps:
+                    if '=' in ubuntu_dep:
+                        packages.add(ubuntu_dep)
 
-    print(f"Manually installing the following packages via APT, before rosdep scan:")
-    for package in packages:
-        print(f"  - {package}")
+    if len(packages) > 0:
+        print(f"Manually installing the following packages via APT, before rosdep scan:")
+        for package in packages:
+            print(f"  - {package}")
 
-    run_command("apt update")
-    run_command(f"apt install -y {' '.join(sorted(packages))}")
+        run_command("apt update")
+        run_command(f"apt install -y {' '.join(sorted(packages))}")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
### Changes

- Add scripts and instructions to debianize ros packages locally
- Alter behavior of `rosdep_install.py`: previously it would install all dependencies listed in a rosdep.yaml file, now it will only install dependencies which are explicitly pinned. This was done to prevent apt from reinstalling over manually installed debs during local builds.